### PR TITLE
chore: set `files` field in `package.json`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-node_modules
-dist/tests
-tsconfig.json
-coverage
-tests
-bench

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "!dist/*.tsbuildinfo"
+    "!dist/*.tsbuildinfo",
+    "!dist/src"
+    "!dist/tests"
   ],
   "engines": {
     "node": "^14 || ^16 || >=18"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "!dist/*.tsbuildinfo",
+    "!dist/**/*.tsbuildinfo",
     "!dist/src"
     "!dist/tests"
   ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "!dist/*.tsbuildinfo"
+  ],
   "engines": {
     "node": "^14 || ^16 || >=18"
   },


### PR DESCRIPTION
congrats for making such a tiny package! it looks like it's publishing many project files to npm, making the install size [133KB](https://pkg-size.dev/banditypes), 90KB+ of it being files that are simply not relevant for users, such as `.tsbuildinfo` files. This PR sets the [`files`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files) field to only publish what's needed :+1:

There was the `.npmignore` file which was removed in this PR as it's better to provide a list of what to include rather than what not to include.

It looks like `dist` contains 3 copies of the package instead of the two (cjs, esm) needed for a dual package. Ignoring `./dist/src` could decrease the package size some more, as it seems like that directory is never used or exported